### PR TITLE
Handle vonage call exception

### DIFF
--- a/vocode/streaming/telephony/conversation/vonage_call.py
+++ b/vocode/streaming/telephony/conversation/vonage_call.py
@@ -116,6 +116,13 @@ class VonageCall(Call[VonageOutputDevice]):
                 self.logger.debug("Websocket disconnected")
                 disconnected = True
                 break
+            except KeyError as ex:
+                self.logger.debug(f"Websocket got KeyError: {ex}")
+                continue
+            except Exception as ex:
+                self.logger.debug(f"Websocket disconnected, unexpected exception: {ex}")
+                disconnected = True
+                break
         if not disconnected:
             await ws.close()
         await self.config_manager.delete_config(self.id)


### PR DESCRIPTION
When users press any button (action) during the call, VonageCall will get the exception and crash as shown in the screenshot below.
So we'll have to catch the error, if it's due to action we can skip it and continue the call, otherwise we can stop the call immediately

![2023-09-29T17:27:52](https://github.com/fleetworks-team/vocode-python/assets/11568632/b1c42fc4-b3ca-488b-8483-4c083da661c5)